### PR TITLE
gamma threshold, more fill checks, max hedges

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -52,3 +52,5 @@ export const monthAdj = 1; // Adjustment since Date.UTC is zero based
 export const zScore = 1.282; // Corresponds to 80% CI
 export const fillScan = 1; // Number of seconds during twap intervals to check for websocket fills
 export const percentDrift = 0.05; // Percentage of time to allow drift of the timed actions
+export const gammaThreshold = 0.05; // Percentage of gamma to calc delta hedge threshold
+export const maxHedges = 10; // Maximum amount of orders to delta hedge across


### PR DESCRIPTION
Reduce our sensitivity to delta hedging as a function of gamma. We assume anything within 5% of the gamma amount that we hedge is considered delta neutral. Avoids issues when position sizes become large and it being difficult to get delta neutral.
https://github.com/Dual-Finance/risk-manager/issues/32

Check for fills each second from loadfFills() & WS

Only allow a twap delta hedge to have 10 clips https://github.com/Dual-Finance/risk-manager/issues/34