### PR TITLE
Only call cancelAll once, not repeatedly the same for each order

### DIFF
--- a/src/scalper.ts
+++ b/src/scalper.ts
@@ -472,22 +472,17 @@ export class Scalper {
   ): Promise<void> {
     const openOrders = mangoAccount.getPerpOpenOrders();
     if (openOrders.length > 0) {
-      for (const order of openOrders) {
-        if (order.marketIndex == this.marketIndex) {
-          try{
-            console.log(this.symbol,"Canceling Orders");
-            await this.client.cancelAllPerpOrders(
-              mangoGroup,
-              [perpMarket],
-              mangoAccount,
-              this.owner
-            );
-          } catch (err) {
-            console.log(err);
-            console.log(err.stack);
-          }
-          break;
-        }
+      try{
+        console.log(this.symbol,"Canceling Orders");
+        await this.client.cancelAllPerpOrders(
+          mangoGroup,
+          [perpMarket],
+          mangoAccount,
+          this.owner
+        );
+      } catch (err) {
+        console.log(err);
+        console.log(err.stack);
       }
     }
   }


### PR DESCRIPTION
I think the intention was to call cancelPerpOrder, but the cancelAll should only need to be done once

The issue is that we may be calling cancelAll here a lot if there are many orders that didnt get properly cancelled before