### PR TITLE
Strike adjustments for unhedgable delta

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -55,7 +55,7 @@ export const MODE = new Map<SYMBOL, number>([
   ['SOL', parseFloat(solVars[4]) > 0 ? parseFloat(solVars[4]) : 0],
   ['MNGO', parseFloat(mngoVars[4]) > 0 ? parseFloat(mngoVars[4]) : 0],
   ['BONK', parseFloat(bonkVars[4]) > 0 ? parseFloat(bonkVars[4]) : 0],
-]); // 0 - Normal 1 - Gamma+Back 2- Back Only
+]); // 0 - Normal 1 - Gamma+Back 2 - Gamma+Back w/ Strike Adjustment 3- Back Only
 
 export const ENVIRONMENT: string = IS_DEV ? 'DEVNET' : 'MAINNET';
 

--- a/src/scalper.ts
+++ b/src/scalper.ts
@@ -18,13 +18,14 @@ import {
   treasuryPositions, slippageMax, gammaCompleteThresholdPct, cluster,
   maxOrderBookSearchDepth, maxBackGammaMultiple, API_URL, MODE, whaleMaxSpread, SYMBOL,
 } from './config';
-import { DIPDeposit } from './common';
+import { CallOrPut, DIPDeposit } from './common';
 import { readKeypair, sleepExact, sleepRandom } from './utils';
 import { SerumVialClient, SerumVialTradeMessage } from './serumVial';
 import {
   jupiterHedge, cancelTxOpenBookOrders, getDIPDelta, getDIPGamma, getDIPTheta,
   getFairValue, getPayerAccount, getSpotDelta, loadPrices, orderSpliceMango,
   liquidityCheckAndNumSplices, settleOpenBook, setPriorityFee, waitForGamma, waitForFill,
+  findMaxStrike, findMinStrike, findNearestStrikeType,
 } from './scalper_utils';
 import { OPENBOOK_MKT_MAP } from './constants';
 
@@ -1050,8 +1051,56 @@ class Scalper {
       : dipTotalGamma * stdDevSpread * fairValue;
 
     const widenSpread = (gammaScalpCount - 1) / gammaCycles;
-    const gammaBid = fairValue * (1 - stdDevSpread - stdDevSpread * widenSpread);
-    const gammaAsk = fairValue * (1 + stdDevSpread + stdDevSpread * widenSpread);
+    let gammaBid = fairValue * (1 - stdDevSpread - stdDevSpread * widenSpread);
+    let gammaAsk = fairValue * (1 + stdDevSpread + stdDevSpread * widenSpread);
+
+    // Adjust gamma prices based on strike
+    // TODO: Determine if should always have this on or only on products we can't get delta neutral
+    if (this.mode === 2) {
+      const dipTotalDelta = getDIPDelta(dipProduct, fairValue, this.symbol);
+      const spotDelta = await getSpotDelta(this.connection, this.symbol);
+      const isShort = dipTotalDelta + spotDelta + this.deltaOffset < 0;
+      // TODO: Create a gamma table to find relevant long & short strikes
+      const nearStrikeType = findNearestStrikeType(dipProduct, fairValue);
+      console.log(this.symbol, 'Delta Position', dipTotalDelta + spotDelta + this.deltaOffset, nearStrikeType, 'isShort', isShort);
+      if (nearStrikeType === CallOrPut.Put) {
+        const isOTM = (fairValue > dipProduct[0].strikeUsdcPerToken);
+        const maxStrike = findMaxStrike(dipProduct);
+        if (isOTM && isShort) {
+          gammaBid = Math.min(
+            maxStrike * (1 - stdDevSpread - stdDevSpread * widenSpread),
+            gammaBid,
+          );
+          console.log('Strike Adjusted Gamma Bid', gammaBid, maxStrike);
+        }
+        if (!isOTM && isShort) {
+          gammaAsk = Math.max(
+            maxStrike * (1 + stdDevSpread + stdDevSpread * widenSpread),
+            gammaAsk,
+          );
+          console.log('Strike Adjusted Gamma Ask', gammaAsk, maxStrike);
+        }
+      }
+      // TODO: Check All Call Adjustment logic
+      if (nearStrikeType === CallOrPut.Call) {
+        const isOTM = (fairValue < dipProduct[0].strikeUsdcPerToken);
+        const minStrike = findMinStrike(dipProduct);
+        if (isOTM && !isShort) {
+          gammaAsk = Math.max(
+            minStrike * (1 + stdDevSpread + stdDevSpread * widenSpread),
+            gammaAsk,
+          );
+          console.log('Strike Adjusted Gamma Ask', gammaAsk, minStrike);
+        }
+        if (!isOTM && !isShort) {
+          gammaBid = Math.min(
+            minStrike * (1 - stdDevSpread - stdDevSpread * widenSpread),
+            gammaBid,
+          );
+          console.log('Strike Adjusted Gamma Bid', gammaBid, minStrike);
+        }
+      }
+    }
 
     console.log(this.symbol, 'Position Gamma Γ:', netGamma, 'Fair Value', fairValue);
     if ((netGamma * fairValue) < (this.minSpotSize * fairValue)) {
@@ -1094,7 +1143,7 @@ Spread % ${((whaleAskPrice - whaleBidPrice) / fairValue) * 100}`);
     const bidAccount = getPayerAccount('buy', this.symbol, 'USDC');
     const askAccount = getPayerAccount('sell', this.symbol, 'USDC');
     const gammaOrders = new Transaction();
-    if (this.mode < 2) {
+    if (this.mode < 3) {
       const gammaBidTx = await spotMarket.makePlaceOrderTransaction(this.connection, {
         owner: this.owner.publicKey,
         payer: bidAccount,

--- a/src/scalper_utils.ts
+++ b/src/scalper_utils.ts
@@ -13,7 +13,7 @@ import { getAssociatedTokenAddress } from '@project-serum/associated-token';
 import fetch from 'node-fetch';
 import { Jupiter } from '@jup-ag/core';
 import JSBI from 'jsbi';
-import { DIPDeposit, RouteDetails } from './common';
+import { CallOrPut, DIPDeposit, RouteDetails } from './common';
 import {
   ACCOUNT_MAP,
   JUPITER_LIQUIDITY,
@@ -519,4 +519,35 @@ export function waitForGamma(conditionFunction) {
     else setTimeout((_) => poll(resolve), resolvePeriodMs);
   };
   return new Promise(poll);
+}
+
+// Find the max strike of a set of DIPs/SOs
+export function findMaxStrike(dipProduct: DIPDeposit[]) {
+  let strikeMax = dipProduct[0].strikeUsdcPerToken;
+  for (const dip of dipProduct) {
+    if (dip.strikeUsdcPerToken > strikeMax) { strikeMax = dip.strikeUsdcPerToken; }
+  }
+  return strikeMax;
+}
+
+// Find the min strike of a set of DIPs/SOs
+export function findMinStrike(dipProduct: DIPDeposit[]) {
+  let strikeMin = dipProduct[0].strikeUsdcPerToken;
+  for (const dip of dipProduct) {
+    if (dip.strikeUsdcPerToken < strikeMin) { strikeMin = dip.strikeUsdcPerToken; }
+  }
+  return strikeMin;
+}
+
+// Find the nearest strike of a set of DIPs/SOs
+export function findNearestStrikeType(dipProduct: DIPDeposit[], fairValue: number) {
+  let nearestStrike = dipProduct[0].strikeUsdcPerToken;
+  let nearStrikeType: CallOrPut;
+  for (const dip of dipProduct) {
+    if (Math.abs(dip.strikeUsdcPerToken - fairValue) < Math.abs(nearestStrike - fairValue)) {
+      nearestStrike = dip.strikeUsdcPerToken;
+      nearStrikeType = dip.callOrPut;
+    }
+  }
+  return nearStrikeType;
 }


### PR DESCRIPTION
When the assets is too illiquid and the Risk Manager is stuck in a delta position, adjust the gamma price based on the nearest strike type, net delta position & if ITM/OTM

Four cases to adjust

Puts:
1. OTM & Short (current case for MNGO) - Don't buy above the put strike since can't guarantee you will be able to sell it, charm protection
2. ITM & Short - Don't sell below the put strike, you can just exercise it instead later

Calls:
3. OTM & Long - Don't sell below call strike, avoid crushing the price, charm protection
4. ITM & Long - Don't buy above the call strike, you can just exercise it instead later