### PR TITLE
Round to atoms

### DIFF
--- a/src/poller.ts
+++ b/src/poller.ts
@@ -53,7 +53,7 @@ class Poller {
 
       const tokenQty = this.callOrPut === CallOrPut.Call
         ? newAmountAtoms / NUM_DIP_ATOMS_PER_TOKEN
-        : (newAmountAtoms / NUM_DIP_ATOMS_PER_TOKEN) / this.strikeTokens;
+        : Math.floor(newAmountAtoms / this.strikeTokens) / NUM_DIP_ATOMS_PER_TOKEN;
       const strikeUsdcPerToken = this.callOrPut === CallOrPut.Call
         ? this.strikeTokens
         : Number((this.strikeTokens).toPrecision(6));

--- a/src/router.ts
+++ b/src/router.ts
@@ -16,7 +16,7 @@ import {
 } from './utils';
 import * as apiSecret from '../apiSecret.json';
 import {
-  DIP_STATE_LENGTH, DIP_PROGRAM_ID, MS_PER_YEAR,
+  DIP_STATE_LENGTH, DIP_PROGRAM_ID, MS_PER_YEAR, NUM_DIP_ATOMS_PER_TOKEN,
   OPTION_VAULT_PK, OPTION_MINT_ADDRESS_SEED, PROTCOL_API_KEY, SIX_MONTHS_IN_MS,
 } from './constants';
 import { dipToString, fetchMMOrder } from './router_utils';
@@ -128,9 +128,7 @@ class Router {
       const clientOrderId = `clientOrderId${Date.now()}`;
       const side = 'SELL';
       const quantityDIP = dipDeposit.qtyTokens;
-      const quantityTrade = dipDeposit.callOrPut === CallOrPut.Call
-        ? Math.min(quantityDIP, remainingQuantity)
-        : Math.min(quantityDIP, remainingQuantity) * dipDeposit.strikeUsdcPerToken;
+      const quantityTrade = Math.min(quantityDIP, remainingQuantity);
       // @ts-ignore
       const secret = apiSecret.default;
 
@@ -261,7 +259,8 @@ class Router {
       : splMintToToken(baseMint);
     const tokenQty = callOrPut === CallOrPut.Call
       ? Number(balance.value.uiAmount)
-      : Number((Number(balance.value.uiAmount) / strikeUsdcPerToken).toPrecision(6));
+      : Math.floor((Number(balance.value.uiAmount) / strikeUsdcPerToken)
+        * NUM_DIP_ATOMS_PER_TOKEN) / NUM_DIP_ATOMS_PER_TOKEN;
     this.dips[dipToString(expirationSec, strikeUsdcPerToken, callOrPut)] = {
       splTokenName,
       premiumAssetName,


### PR DESCRIPTION
Removes precision on quantity and uses atoms so there aren't any overflows to the API. Removes the call/put quantity in Route since it gets that from the poller